### PR TITLE
Makefile to render yml from cue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+cue_files := $(shell find ./inventory -name "*.cue")
+yaml_files := $(patsubst %.cue,%.yml,$(cue_files))
+
+all: clean cue
+	kapitan compile
+
+.PHONY: cue
+cue: $(yaml_files)
+
+%.yml: %.cue
+	cue export $< --outfile $@ --out yaml
+
+.PHONY: clean
+clean:
+	$(RM) $(yaml_files)
+


### PR DESCRIPTION
Allows classes and targets to be written in cuelang. No need to worry about indentation or any other yaml shenanigans.